### PR TITLE
Add simple type alias guidelines

### DIFF
--- a/guide/guide.md
+++ b/guide/guide.md
@@ -109,6 +109,30 @@ Put spaces before and after `as`:
 let cstr = "Hi\0" as *const str as *const [u8] as *const std::os::raw::c_char;
 ```
 
+### Type Aliases
+
+A type alias should follow normal line break rules. If one must break the line,
+then do it after the `=` first, and after the `type` next. Keep the type alias
+and `=` on the same line. Keep `pub` and `type` on the same line. If one must
+break, indent exactly once from the indentation of `type`.
+
+#### Single-line
+
+```rust
+[pub] type FooBar = Baz<i32>;
+```
+
+#### Multi-line
+
+```rust
+[pub] type ShorterName =
+  VeryLongName<Perhaps, With, Type, Parameters>;
+
+[pub] type
+  QuiteLongName =
+  FooBarBazQuxx;
+```
+
 ### Tuples and tuple structs
 
 Write the type list as you would a parameter list to a function.

--- a/guide/guide.md
+++ b/guide/guide.md
@@ -119,18 +119,19 @@ break, indent exactly once from the indentation of `type`.
 #### Single-line
 
 ```rust
-[pub] type FooBar = Baz<i32>;
+type FooBar = Baz<i32>;
+pub type FooBar = Baz<i32>;
 ```
 
 #### Multi-line
 
 ```rust
-[pub] type ShorterName =
-  VeryLongName<Perhaps, With, Type, Parameters>;
+type ShorterName =
+    VeryLongName<Perhaps, With, Type, Parameters>;
 
-[pub] type
-  QuiteLongName =
-  FooBarBazQuxx;
+pub type
+    QuiteLongName =
+    FooBarBazQuxx;
 ```
 
 ### Tuples and tuple structs


### PR DESCRIPTION
I'd like to note that whether the `=` sign is on the same line as the type alias, or the aliased type, should be dependent on what we choose later for binary ops split across lines. I've gone with on the same line as the type alias for now, as that's what I wrote in the issue.