### PR TITLE
Update expressions.md

### DIFF
--- a/guide/expressions.md
+++ b/guide/expressions.md
@@ -312,6 +312,18 @@ match foo {
 }
 ```
 
+The `=>` in the match should be in a straight column.
+
+Examples:
+
+```rust
+match foo {
+   foo       => bar,
+   foofoo    => barbar,
+   foofoofoo => barbarbar,
+}
+```
+
 If the body is a single expression with no line comments is a *combinable
 expression* (see below for details), then it may be started on the same line as
 the right-hand side. If not, then it must be in a block. Example,


### PR DESCRIPTION
I think we should enforce the '=>' in match expressions be in a straight column.  This makes code much easier to read, and since we will be using an automatic formatting tool, it's not hard to keep up-to-date (the usual argument against such a style).  I also think the types in a struct definition should be in a straight column.